### PR TITLE
Improve cligpt CLI defaults and flags

### DIFF
--- a/cligpt/README.md
+++ b/cligpt/README.md
@@ -2,7 +2,8 @@
 GPT CLI Tool Help & Usage
 -------------------------
 This tool supports both one-off queries and an interactive REPL. It accepts reasoning effort flags to
-customize processing, and a debug flag for extra output.
+customize processing, and a debug flag for extra output. If no subcommand is provided,
+arguments are treated as a query by default.
 
 When the tool starts, it prints a header in the following format:
   [mode: <model_name> - reasoning effort: <reasoning_effort>]
@@ -10,11 +11,11 @@ When the tool starts, it prints a header in the following format:
 If the +debug flag is enabled, additional header information and reasoning tokens are printed.
 
 Flags:
-  -high       Set reasoning effort to high
-  -medium     Set reasoning effort to medium (default)
-  -low        Set reasoning effort to low
-  +debug      Enable debug mode (prints full header & reasoning tokens)
-  -debug      Disable debug mode
+  --high (-h)       Set reasoning effort to high
+  --medium (-m)     Set reasoning effort to medium (default)
+  --low (-l)        Set reasoning effort to low
+  +debug (+d)       Enable debug mode (prints full header & reasoning tokens)
+  -debug (-d)       Disable debug mode
 
 Please refer to this file for setup and usage instructions.
 
@@ -47,7 +48,8 @@ easier.
 ## Usage
 
 Usage Examples:
-  • gpt_cli.py query -high "inquiry text"
-  • gpt_cli.py -low
+  • gpt_cli.py --high "inquiry text"
+  • gpt_cli.py --low
   • gpt_cli.py +debug
-  • gpt_cli.py +debug -medium
+  • gpt_cli.py +debug --medium
+  • gpt_cli.py --model gpt-4 "use a specific model"

--- a/cligpt/ai_client.py
+++ b/cligpt/ai_client.py
@@ -75,16 +75,18 @@ def load_system_message():
     
     return formatted_message + "\n\n" + neofetch_info
 
-def single_query(user_prompt, reasoning_effort="medium", debug=False):
+def single_query(user_prompt, reasoning_effort="medium", debug=False, model=None):
     """
     Send a query to the AI using the specified reasoning effort.
     A header is printed at the beginning of each response:
       [<model_name> - <reasoning_effort>]
     Streaming is disabled.
     """
-    # Default reasoning_effort to "medium" if not provided.
+    # Default parameters if not provided.
     if not reasoning_effort:
         reasoning_effort = "medium"
+    if not model:
+        model = MODEL
 
     system_message = load_system_message()
     pruned_context, chat_blocks, topic_tags, oldest_block = prune_context(user_prompt)
@@ -97,7 +99,7 @@ def single_query(user_prompt, reasoning_effort="medium", debug=False):
     total_context_tokens = system_tokens + context_tokens + user_tokens
 
     # Build header
-    header_basic = f"[{MODEL} - {reasoning_effort}]"
+    header_basic = f"[{model} - {reasoning_effort}]"
     debug_header = (f"[Context Tokens: {total_context_tokens}]\n"
                     f"  [System Message: {system_tokens}]\n"
                     f"  [Pruned Context: {context_tokens}]\n"
@@ -120,7 +122,7 @@ def single_query(user_prompt, reasoning_effort="medium", debug=False):
     
     # Always disable streaming.
     response = client.chat.completions.create(
-        model=MODEL,
+        model=model,
         messages=messages,
         max_completion_tokens=MAX_CONTEXT_TOKENS,
         response_format={"type": "json_schema", "json_schema": RESPONSE_SCHEMA},


### PR DESCRIPTION
## Summary
- default to the `query` subcommand when args look like a prompt
- allow selecting the model with `-m/--model`
- accept short REPL flags (`+d`, `-d`, `-h`, `-m`, `-l`)
- rename reasoning flags to `--high`, `--medium`, and `--low`
- update help text and README to match new behaviour

## Testing
- `python3 -m py_compile cligpt/cli_interface.py cligpt/ai_client.py`

------
https://chatgpt.com/codex/tasks/task_e_6871c70446fc832fabb95de5d1c7aeae